### PR TITLE
feat: refresh guest UI with glassmorphism and docker runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,50 +1,37 @@
-# Base environment with pnpm enabled
+# Production-ready image for the Monotickets frontend (guest app)
 FROM node:20-alpine AS base
 WORKDIR /app
-RUN apk add --no-cache libc6-compat
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
-RUN corepack enable && corepack prepare pnpm@10.18.0 --activate
+RUN apk add --no-cache libc6-compat \
+  && corepack enable \
+  && corepack prepare pnpm@10.18.0 --activate
 
-# Install dependencies once to leverage Docker layer caching
+# Install dependencies with pnpm using workspace filters for the guest app
 FROM base AS deps
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml turbo.json tsconfig.json ./
-COPY apps ./apps
 COPY packages ./packages
-RUN pnpm install --frozen-lockfile
+COPY apps/guest/package.json ./apps/guest/package.json
+RUN pnpm install --filter guest... --frozen-lockfile
 
-# Build the selected application
+# Build the Next.js application with standalone output
 FROM base AS builder
-ARG APP_NAME=admin
-ARG APP_DIR=apps/admin
 ARG NEXT_PUBLIC_API_URL=https://api.monotickets.com
-ENV NODE_ENV=production
 ENV NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL}
-ENV APP_NAME=${APP_NAME}
-ENV APP_DIR=${APP_DIR}
 COPY . .
 COPY --from=deps /app/node_modules ./node_modules
-RUN pnpm install --frozen-lockfile
-RUN pnpm --filter ${APP_NAME}... build
+RUN pnpm install --filter guest... --frozen-lockfile
+RUN pnpm --filter guest... build
 
-# Final runtime image
-FROM base AS runner
-ARG APP_NAME=admin
-ARG APP_DIR=apps/admin
-ARG NEXT_PUBLIC_API_URL=https://api.monotickets.com
-ENV NODE_ENV=production
-ENV NEXT_TELEMETRY_DISABLED=1
-ENV NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL}
-ENV APP_NAME=${APP_NAME}
-ENV APP_DIR=${APP_DIR}
+# Final runtime image using the standalone server
+FROM node:20-alpine AS runner
 WORKDIR /app
-COPY --from=builder /app/pnpm-lock.yaml ./pnpm-lock.yaml
-COPY --from=builder /app/package.json ./package.json
-COPY --from=builder /app/pnpm-workspace.yaml ./pnpm-workspace.yaml
-COPY --from=builder /app/tsconfig.json ./tsconfig.json
-COPY --from=builder /app/turbo.json ./turbo.json
-COPY --from=builder /app/node_modules ./node_modules
-COPY --from=builder /app/packages ./packages
-COPY --from=builder /app/apps/${APP_DIR} ./apps/${APP_DIR}
+ENV NODE_ENV=production
+ENV PORT=3000
+ARG NEXT_PUBLIC_API_URL=https://api.monotickets.com
+ENV NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL}
+COPY --from=builder /app/apps/guest/.next/standalone ./
+COPY --from=builder /app/apps/guest/.next/static ./apps/guest/.next/static
+COPY --from=builder /app/apps/guest/public ./apps/guest/public
 EXPOSE 3000
-CMD ["sh", "-c", "pnpm --filter \"$APP_NAME\" start"]
+CMD ["node", "apps/guest/server.js"]

--- a/apps/guest/app/create/page.tsx
+++ b/apps/guest/app/create/page.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import React, { useState } from 'react';
+import { Button, Card } from '@ui/index';
+import { motion } from 'framer-motion';
+
+export default function CreateEventPage() {
+  const [name, setName] = useState('');
+  const [date, setDate] = useState('');
+  const [location, setLocation] = useState('');
+  const [submitted, setSubmitted] = useState(false);
+
+  return (
+    <motion.section initial={{ opacity: 0, y: 24 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.4 }} className="mx-auto max-w-3xl space-y-6">
+      <header className="space-y-2">
+        <p className="badge inline-flex">Crear evento</p>
+        <h1 className="text-3xl font-semibold text-[var(--color-text-strong)]">Diseña una nueva experiencia</h1>
+        <p className="text-sm text-[var(--color-text-muted)]">
+          Completa los datos principales y visualiza un resumen previo antes de publicar.
+        </p>
+      </header>
+      <Card className="space-y-6">
+        <form
+          className="grid gap-5 sm:grid-cols-2"
+          onSubmit={(event) => {
+            event.preventDefault();
+            setSubmitted(true);
+          }}
+        >
+          <label className="flex flex-col gap-2 text-sm font-medium">
+            Nombre del evento
+            <input
+              required
+              value={name}
+              onChange={(event) => setName(event.target.value)}
+              className="rounded-2xl border border-[var(--color-border-soft)] bg-[rgba(255,255,255,0.05)] px-4 py-3 text-[var(--color-text)] shadow-soft transition-base focus-visible:border-[var(--color-accent)]"
+              placeholder="Ej. Networking Nocturno"
+            />
+          </label>
+          <label className="flex flex-col gap-2 text-sm font-medium">
+            Fecha
+            <input
+              type="date"
+              required
+              value={date}
+              onChange={(event) => setDate(event.target.value)}
+              className="rounded-2xl border border-[var(--color-border-soft)] bg-[rgba(255,255,255,0.05)] px-4 py-3 text-[var(--color-text)] shadow-soft transition-base focus-visible:border-[var(--color-accent)]"
+            />
+          </label>
+          <label className="sm:col-span-2 flex flex-col gap-2 text-sm font-medium">
+            Ubicación
+            <input
+              required
+              value={location}
+              onChange={(event) => setLocation(event.target.value)}
+              className="rounded-2xl border border-[var(--color-border-soft)] bg-[rgba(255,255,255,0.05)] px-4 py-3 text-[var(--color-text)] shadow-soft transition-base focus-visible:border-[var(--color-accent)]"
+              placeholder="Dirección o formato híbrido"
+            />
+          </label>
+          <div className="sm:col-span-2 flex justify-end">
+            <Button type="submit" disabled={!name || !date || !location}>
+              Guardar borrador
+            </Button>
+          </div>
+        </form>
+        {submitted && (
+          <div className="rounded-3xl border border-[var(--color-border-soft)] bg-[rgba(75,163,255,0.12)] px-5 py-4 text-sm text-[var(--color-text-strong)]">
+            <p className="font-semibold">¡Borrador creado!</p>
+            <p className="text-[var(--color-text-muted)]">
+              Revisa los detalles y activa la venta de boletos cuando estés listo. El modo oscuro permanece según tu preferencia.
+            </p>
+          </div>
+        )}
+      </Card>
+    </motion.section>
+  );
+}

--- a/apps/guest/app/events/page.tsx
+++ b/apps/guest/app/events/page.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import React from 'react';
+import { Card } from '@ui/index';
+import { motion } from 'framer-motion';
+import { usePreserveScroll } from '@hooks/usePreserveScroll';
+
+const events = [
+  {
+    id: 'aurora',
+    title: 'Aurora Sessions',
+    date: '15 nov 2024',
+    status: 'Próximo',
+    attendees: 480,
+  },
+  {
+    id: 'summit',
+    title: 'Summit Creativo 2024',
+    date: '23 nov 2024',
+    status: 'En curso',
+    attendees: 950,
+  },
+  {
+    id: 'classic',
+    title: 'Noches Clásicas',
+    date: '8 dic 2024',
+    status: 'Planeado',
+    attendees: 320,
+  },
+];
+
+export default function EventsPage() {
+  usePreserveScroll('dashboard-events');
+
+  return (
+    <motion.section initial={{ opacity: 0, y: 24 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.4 }} className="space-y-6">
+      <header className="space-y-2">
+        <p className="badge inline-flex">Mis eventos</p>
+        <h1 className="text-3xl font-semibold text-[var(--color-text-strong)]">Gestiona tus experiencias</h1>
+        <p className="text-sm text-[var(--color-text-muted)]">
+          Visualiza estadísticas rápidas y mantén tu posición de scroll al volver desde cualquier detalle.
+        </p>
+      </header>
+      <div className="grid gap-5 lg:grid-cols-2 xl:grid-cols-3">
+        {events.map((event) => (
+          <Card key={event.id} className="flex h-full flex-col gap-4">
+            <div className="flex items-start justify-between">
+              <div>
+                <h2 className="text-xl font-semibold text-[var(--color-text-strong)]">{event.title}</h2>
+                <p className="text-sm text-[var(--color-text-muted)]">{event.date}</p>
+              </div>
+              <span className="rounded-full bg-[rgba(75,163,255,0.18)] px-3 py-1 text-xs font-semibold text-[var(--color-text-strong)]">
+                {event.status}
+              </span>
+            </div>
+            <p className="text-sm text-[var(--color-text)]">Entradas confirmadas: {event.attendees.toLocaleString('es-MX')}</p>
+            <div className="mt-auto flex flex-wrap gap-3 text-xs text-[var(--color-text-muted)]">
+              <span>• RSVP activos con recordatorios automáticos</span>
+              <span>• Check-in con QR dinámico</span>
+            </div>
+          </Card>
+        ))}
+      </div>
+    </motion.section>
+  );
+}

--- a/apps/guest/app/feedback/page.tsx
+++ b/apps/guest/app/feedback/page.tsx
@@ -1,16 +1,28 @@
 'use client';
+
 import { FeedbackForm } from '../../components/FeedbackForm';
 import { motion } from 'framer-motion';
 import React from 'react';
 
 /**
- * Post-event feedback page.  Wraps the feedback form in a motion
- * component for a smooth entrance animation.
+ * Post-event feedback page with refreshed styling.
  */
 export default function FeedbackPage() {
   return (
-    <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} className="max-w-md">
+    <motion.section
+      initial={{ opacity: 0, y: 24 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.4, ease: 'easeOut' }}
+      className="mx-auto max-w-2xl space-y-6"
+    >
+      <header className="space-y-2 text-center">
+        <p className="badge inline-flex">Queremos escucharte</p>
+        <h1 className="text-3xl font-semibold text-[var(--color-text-strong)]">Feedback</h1>
+        <p className="text-sm text-[var(--color-text-muted)]">
+          Envía tus comentarios y ayuda a optimizar la experiencia completa de Monotickets.
+        </p>
+      </header>
       <FeedbackForm />
-    </motion.div>
+    </motion.section>
   );
 }

--- a/apps/guest/app/globals.css
+++ b/apps/guest/app/globals.css
@@ -1,11 +1,174 @@
-/*
-  Global styles for the guest module.  Pull in Tailwind’s base, component,
-  and utility styles.  Additional global overrides can be added below.
-*/
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500&family=Montserrat:wght@700&family=Poppins:wght@600&display=swap');
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 
+:root {
+  --color-background: #0d1b2a;
+  --color-background-muted: #11243a;
+  --color-surface: rgba(255, 255, 255, 0.08);
+  --color-surface-elevated: rgba(13, 27, 42, 0.75);
+  --color-surface-alt: #ffffff;
+  --color-text: #b0b0b0;
+  --color-text-strong: #ffffff;
+  --color-text-muted: #8891a5;
+  --color-accent: #4ba3ff;
+  --color-accent-strong: #6cb6ff;
+  --color-border: #e0e0e0;
+  --color-border-soft: rgba(255, 255, 255, 0.18);
+  --shadow-elevated: 0 18px 45px rgba(4, 9, 20, 0.45);
+  --blur-strength: 18px;
+  --font-heading: 'Montserrat', 'Montserrat Variable', sans-serif;
+  --font-subheading: 'Poppins', 'Poppins Variable', sans-serif;
+  --font-body: 'Inter', 'Inter Variable', 'Roboto', system-ui, -apple-system, sans-serif;
+  color-scheme: dark light;
+}
+
+[data-theme='dark'] {
+  --color-background: #0d1b2a;
+  --color-background-muted: #11243a;
+  --color-surface: rgba(19, 35, 53, 0.75);
+  --color-surface-elevated: rgba(13, 27, 42, 0.85);
+  --color-text: #d5d7dc;
+  --color-text-strong: #f7f9fc;
+  --color-text-muted: #a5afc3;
+  --color-border: rgba(255, 255, 255, 0.22);
+  --color-border-soft: rgba(255, 255, 255, 0.16);
+}
+
+[data-theme='light'] {
+  --color-background: #f5f8ff;
+  --color-background-muted: #ffffff;
+  --color-surface: rgba(255, 255, 255, 0.92);
+  --color-surface-elevated: rgba(255, 255, 255, 0.94);
+  --color-text: #384150;
+  --color-text-strong: #0d1b2a;
+  --color-text-muted: #4c5a71;
+  --color-border: #d8dee9;
+  --color-border-soft: rgba(13, 27, 42, 0.08);
+}
+
+@media (prefers-color-scheme: light) {
+  :root:not([data-theme='dark']) {
+    color-scheme: light;
+  }
+}
+
 body {
-  @apply text-gray-900;
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at 15% 20%, rgba(75, 163, 255, 0.18), transparent 45%),
+    radial-gradient(circle at 80% 10%, rgba(75, 163, 255, 0.12), transparent 40%),
+    linear-gradient(160deg, var(--color-background) 0%, var(--color-background-muted) 60%, #071120 100%);
+  color: var(--color-text);
+  transition: background 320ms ease, color 220ms ease;
+  font-feature-settings: 'liga' 1, 'kern' 1;
+  position: relative;
+}
+
+body::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  background: linear-gradient(120deg, rgba(75, 163, 255, 0.08), transparent 65%);
+  pointer-events: none;
+  z-index: -1;
+}
+
+main {
+  width: 100%;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  color: var(--color-text-strong);
+  letter-spacing: -0.02em;
+}
+
+h1 {
+  font-family: var(--font-heading);
+  font-size: clamp(28px, 3vw, 32px);
+  line-height: 1.2;
+}
+
+h2 {
+  font-family: var(--font-subheading);
+  font-size: clamp(22px, 2.3vw, 24px);
+  line-height: 1.3;
+}
+
+h3 {
+  font-family: var(--font-subheading);
+  font-size: clamp(18px, 2vw, 20px);
+  line-height: 1.35;
+}
+
+p,
+span,
+li,
+button,
+input,
+textarea {
+  font-family: var(--font-body);
+  font-size: 16px;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:focus-visible,
+button:focus-visible,
+input:focus-visible,
+textarea:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 3px;
+}
+
+::-webkit-scrollbar {
+  width: 10px;
+}
+
+::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.2);
+  border-radius: 9999px;
+}
+
+.glass-card {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border-soft);
+  backdrop-filter: blur(var(--blur-strength));
+  box-shadow: var(--shadow-elevated);
+}
+
+.glass-popover {
+  background: var(--color-surface-elevated);
+  border: 1px solid var(--color-border-soft);
+  backdrop-filter: blur(calc(var(--blur-strength) + 6px));
+  box-shadow: 0 20px 50px rgba(7, 17, 32, 0.45);
+}
+
+.badge {
+  border-radius: 999px;
+  padding: 0.125rem 0.75rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-text-strong);
+  background: linear-gradient(120deg, rgba(75, 163, 255, 0.85), rgba(108, 182, 255, 0.75));
+}
+
+.shadow-soft {
+  box-shadow: 0 12px 38px rgba(4, 9, 20, 0.35);
+}
+
+.transition-base {
+  transition: all 220ms ease;
 }

--- a/apps/guest/app/invite/[token]/page.tsx
+++ b/apps/guest/app/invite/[token]/page.tsx
@@ -1,19 +1,25 @@
 import { InviteCard } from '../../../components/InviteCard';
 import React from 'react';
-import { env } from '@env/index';
 
 /**
- * Server-rendered page that fetches invitation details based on a token
- * parameter from the URL.  It uses fetch to retrieve data from the API
- * without caching.
+ * Server-rendered page that fetches invitation details based on a token.
+ * The invitation is displayed inside a glass-styled card following the
+ * refreshed UI guidelines.
  */
 export default async function InvitePage({ params }: { params: { token: string } }) {
-  // SSR: Obtener datos del invitado desde API
   const data = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/guest/invite/${params.token}`, {
     cache: 'no-store',
-  }).then((r) => r.json());
+  }).then((response) => response.json());
+
   return (
-    <div className="max-w-lg">
+    <div className="mx-auto max-w-3xl space-y-6">
+      <header className="space-y-2">
+        <p className="badge">Invitación digital</p>
+        <h1 className="text-3xl font-semibold text-[var(--color-text-strong)]">Detalle del evento</h1>
+        <p className="text-sm text-[var(--color-text-muted)]">
+          Comparte tu pase y confirma asistencia en segundos. Conservamos tu posición de scroll cuando regreses a la lista de eventos.
+        </p>
+      </header>
       <InviteCard invite={data} />
     </div>
   );

--- a/apps/guest/app/layout.tsx
+++ b/apps/guest/app/layout.tsx
@@ -1,24 +1,23 @@
 import './globals.css';
-import { tokens } from '@tokens/index';
 import React from 'react';
 import { Toast } from '@ui/index';
+import { ThemeProvider } from '../components/ThemeProvider';
+import { AppShell } from '../components/AppShell';
 
-/**
- * Root layout for the guest application.  Centers the content on the page
- * and applies a minimum height to fill the viewport.  Global fonts and
- * background colors are pulled from the design tokens.
- */
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="es">
+    <html lang="es" suppressHydrationWarning>
       <body
+        className="antialiased"
         style={{
-          fontFamily: tokens.typography.fontFamily,
-          backgroundColor: tokens.colors.background,
+          fontFamily: 'var(--font-body)',
+          backgroundColor: 'var(--color-background)',
         }}
-        className="min-h-screen flex flex-col items-center justify-center p-6"
       >
-        {children}
+        <ThemeProvider>
+          <AppShell>{children}</AppShell>
+          <Toast />
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/apps/guest/app/page.tsx
+++ b/apps/guest/app/page.tsx
@@ -1,30 +1,104 @@
 'use client';
+
 import Link from 'next/link';
 import { motion } from 'framer-motion';
 import { Button, Card } from '@ui/index';
 import React from 'react';
+import { TicketPurchaseFlow } from '../components/TicketPurchaseFlow';
+
+const heroVariants = {
+  initial: { opacity: 0, y: 30 },
+  animate: { opacity: 1, y: 0, transition: { duration: 0.6, ease: 'easeOut' } },
+};
+
+const highlightCards = [
+  {
+    title: 'Mis invitaciones',
+    description: 'Consulta tus accesos personalizados, confirma asistencia y comparte con tus invitados.',
+    href: '/events',
+    cta: 'Explorar eventos',
+  },
+  {
+    title: 'Crear un nuevo evento',
+    description: 'Configura experiencias inmersivas en minutos con asistentes automáticos y plantillas listas.',
+    href: '/create',
+    cta: 'Comenzar ahora',
+  },
+  {
+    title: 'Seguimiento de ventas',
+    description: 'Analiza conversiones en tiempo real, recibe alertas y exporta reportes detallados.',
+    href: '/sales',
+    cta: 'Abrir panel',
+  },
+];
 
 /**
- * Landing page for guests.  Provides a welcoming message and asks the
- * visitor to enter their unique invitation token.  Uses a placeholder
- * token in the link for demonstration.
+ * Landing page for guests refreshed with the new design language.  Presents a
+ * hero section, quick navigation cards, and a guided ticket purchase flow.
  */
 export default function HomePage() {
   return (
-    <motion.div
-      className="max-w-md text-center"
-      initial={{ opacity: 0, y: 30 }}
-      animate={{ opacity: 1, y: 0 }}
-    >
-      <Card>
-        <h1 className="text-2xl font-bold mb-3">🎉 Bienvenido a Monotickets</h1>
-        <p className="text-gray-600 mb-6">
-          Si recibiste una invitación, introduce tu token único para acceder.
-        </p>
-        <Link href="/invite/abc123">
-          <Button>Ver mi invitación</Button>
-        </Link>
-      </Card>
-    </motion.div>
+    <div className="space-y-16">
+      <motion.section
+        className="glass-card overflow-hidden rounded-3xl border px-8 py-10 shadow-soft"
+        variants={heroVariants}
+        initial="initial"
+        animate="animate"
+      >
+        <div className="flex flex-col gap-10 lg:flex-row lg:items-center">
+          <div className="max-w-2xl space-y-6">
+            <p className="badge">Experiencias en vivo</p>
+            <h1 className="text-4xl font-bold text-[var(--color-text-strong)] sm:text-5xl">
+              Gestiona y vive tus eventos con una experiencia premium
+            </h1>
+            <p className="text-lg leading-8 text-[var(--color-text)]">
+              Monotickets rediseñó su interfaz para ofrecer flujos claros, modo oscuro inteligente y superficies de
+              glassmorfia que mantienen todo organizado. Compra, comparte y analiza tus eventos sin fricción.
+            </p>
+            <div className="flex flex-wrap gap-4">
+              <Button asChild>
+                <Link href="/ticket/demo">Ver un pase de muestra</Link>
+              </Button>
+              <Button asChild variant="secondary">
+                <Link href="/feedback">Dejar feedback</Link>
+              </Button>
+            </div>
+          </div>
+          <div className="relative flex-1">
+            <div className="absolute -top-12 -right-8 h-40 w-40 rounded-full bg-[rgba(75,163,255,0.18)] blur-3xl" aria-hidden />
+            <div className="glass-popover relative z-10 flex flex-col gap-4 rounded-3xl px-6 py-6 text-left shadow-soft">
+              <p className="text-sm font-medium uppercase tracking-[0.3em] text-[var(--color-text-muted)]">Resumen rápido</p>
+              <div className="flex items-baseline gap-4">
+                <span className="text-5xl font-bold text-[var(--color-text-strong)]">+124k</span>
+                <span className="text-sm text-[var(--color-text-muted)]">Entradas escaneadas en tiempo real</span>
+              </div>
+              <div className="grid gap-3 text-sm text-[var(--color-text)]">
+                <p>• Eventos con confirmación instantánea por QR dinámico.</p>
+                <p>• Panel responsivo con navegación lateral en escritorio y barra móvil.</p>
+                <p>• Preferencias de modo guardadas automáticamente.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </motion.section>
+
+      <section className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+        {highlightCards.map((card) => (
+          <Card key={card.title} className="flex h-full flex-col gap-4 transition-base hover:-translate-y-1 hover:shadow-[0_24px_54px_rgba(75,163,255,0.28)]">
+            <div className="space-y-2">
+              <h3 className="text-xl font-semibold text-[var(--color-text-strong)]">{card.title}</h3>
+              <p className="text-sm leading-6 text-[var(--color-text)]">{card.description}</p>
+            </div>
+            <div className="mt-auto">
+              <Link href={card.href} className="inline-flex items-center gap-2 text-sm font-semibold text-[var(--color-accent)] transition-base hover:text-[var(--color-accent-strong)]">
+                {card.cta} <span aria-hidden>→</span>
+              </Link>
+            </div>
+          </Card>
+        ))}
+      </section>
+
+      <TicketPurchaseFlow />
+    </div>
   );
 }

--- a/apps/guest/app/rsvp/page.tsx
+++ b/apps/guest/app/rsvp/page.tsx
@@ -1,16 +1,28 @@
 'use client';
+
 import { RSVPForm } from '../../components/RSVPForm';
 import { motion } from 'framer-motion';
 import React from 'react';
 
 /**
- * Page for RSVP confirmation.  Wraps the form in a motion component for
- * subtle entrance animation.
+ * Page for RSVP confirmation with glass surfaces and subtle entrance motion.
  */
 export default function RSVPPage() {
   return (
-    <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} className="max-w-md">
+    <motion.section
+      initial={{ opacity: 0, y: 24 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.4, ease: 'easeOut' }}
+      className="mx-auto max-w-xl space-y-6"
+    >
+      <header className="space-y-2 text-center">
+        <p className="badge inline-flex">Confirma tu lugar</p>
+        <h1 className="text-3xl font-semibold text-[var(--color-text-strong)]">RSVP</h1>
+        <p className="text-sm text-[var(--color-text-muted)]">
+          Informa a los organizadores con un clic. Tu preferencia se sincroniza con tus invitaciones en cualquier dispositivo.
+        </p>
+      </header>
       <RSVPForm />
-    </motion.div>
+    </motion.section>
   );
 }

--- a/apps/guest/app/sales/page.tsx
+++ b/apps/guest/app/sales/page.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import React from 'react';
+import { Card } from '@ui/index';
+import { motion } from 'framer-motion';
+
+const metrics = [
+  { label: 'Ingresos en tiempo real', value: '$482,300 MXN', change: '+12% vs. semana anterior' },
+  { label: 'Conversión checkout', value: '68%', change: '+4 puntos porcentuales' },
+  { label: 'Reembolsos', value: '3%', change: '-1% gracias a notificaciones proactivas' },
+];
+
+export default function SalesPage() {
+  return (
+    <motion.section initial={{ opacity: 0, y: 24 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.4 }} className="space-y-6">
+      <header className="space-y-2">
+        <p className="badge inline-flex">Ventas</p>
+        <h1 className="text-3xl font-semibold text-[var(--color-text-strong)]">Desempeño comercial</h1>
+        <p className="text-sm text-[var(--color-text-muted)]">
+          Monitorea métricas clave con tarjetas glassmorphism y contrastes accesibles.
+        </p>
+      </header>
+      <div className="grid gap-5 md:grid-cols-2 xl:grid-cols-3">
+        {metrics.map((metric) => (
+          <Card key={metric.label} className="space-y-3">
+            <p className="text-sm uppercase tracking-[0.25em] text-[var(--color-text-muted)]">{metric.label}</p>
+            <p className="text-3xl font-semibold text-[var(--color-text-strong)]">{metric.value}</p>
+            <p className="text-sm text-[var(--color-text)]">{metric.change}</p>
+          </Card>
+        ))}
+      </div>
+      <Card className="space-y-3">
+        <h2 className="text-xl font-semibold text-[var(--color-text-strong)]">Resumen</h2>
+        <p className="text-sm text-[var(--color-text)]">
+          Habilita notificaciones inteligentes y guarda tu preferencia de modo para recibir alertas según el desempeño del evento.
+        </p>
+      </Card>
+    </motion.section>
+  );
+}

--- a/apps/guest/app/settings/page.tsx
+++ b/apps/guest/app/settings/page.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import React, { useState } from 'react';
+import { Card, Button } from '@ui/index';
+import { motion } from 'framer-motion';
+import { useTheme } from '../../components/ThemeProvider';
+
+export default function SettingsPage() {
+  const { theme, setTheme } = useTheme();
+  const [notifications, setNotifications] = useState(true);
+
+  return (
+    <motion.section initial={{ opacity: 0, y: 24 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.4 }} className="mx-auto max-w-3xl space-y-6">
+      <header className="space-y-2">
+        <p className="badge inline-flex">Ajustes</p>
+        <h1 className="text-3xl font-semibold text-[var(--color-text-strong)]">Preferencias personalizadas</h1>
+        <p className="text-sm text-[var(--color-text-muted)]">
+          Controla el modo, las notificaciones y la privacidad de tus eventos.
+        </p>
+      </header>
+      <Card className="space-y-6">
+        <section className="flex flex-col gap-4">
+          <div className="flex flex-wrap items-center justify-between gap-4">
+            <div>
+              <h2 className="text-xl font-semibold text-[var(--color-text-strong)]">Modo de visualización</h2>
+              <p className="text-sm text-[var(--color-text-muted)]">Elige cómo quieres ver Monotickets.</p>
+            </div>
+            <div className="flex gap-2">
+              <Button variant={theme === 'light' ? 'primary' : 'secondary'} onClick={() => setTheme('light')}>
+                Claro
+              </Button>
+              <Button variant={theme === 'dark' ? 'primary' : 'secondary'} onClick={() => setTheme('dark')}>
+                Oscuro
+              </Button>
+            </div>
+          </div>
+          <div className="flex flex-wrap items-center justify-between gap-4">
+            <div>
+              <h2 className="text-xl font-semibold text-[var(--color-text-strong)]">Notificaciones</h2>
+              <p className="text-sm text-[var(--color-text-muted)]">Recibe alertas cuando se vendan nuevas entradas.</p>
+            </div>
+            <button
+              type="button"
+              onClick={() => setNotifications((prev) => !prev)}
+              className={`relative inline-flex h-10 w-20 items-center rounded-full border border-[var(--color-border-soft)] bg-[rgba(255,255,255,0.05)] transition-base ${
+                notifications ? 'ring-2 ring-[var(--color-accent)] ring-offset-2 ring-offset-[rgba(7,17,32,0.35)]' : ''
+              }`}
+              aria-pressed={notifications}
+              aria-label="Alternar notificaciones"
+            >
+              <span
+                className={`ml-2 inline-flex h-6 w-6 items-center justify-center rounded-full bg-[var(--color-accent)] text-xs font-semibold text-[var(--color-text-strong)] transition-transform ${
+                  notifications ? 'translate-x-8' : 'translate-x-0'
+                }`}
+              >
+                {notifications ? 'On' : 'Off'}
+              </span>
+            </button>
+          </div>
+        </section>
+        <div className="rounded-3xl border border-[var(--color-border-soft)] bg-[rgba(255,255,255,0.06)] px-5 py-4 text-sm text-[var(--color-text)]">
+          Monotickets respeta tus decisiones. Guardamos tus preferencias de modo y notificaciones en tu dispositivo para que la experiencia se mantenga en cada inicio de sesión.
+        </div>
+      </Card>
+    </motion.section>
+  );
+}

--- a/apps/guest/app/ticket/[id]/page.tsx
+++ b/apps/guest/app/ticket/[id]/page.tsx
@@ -2,13 +2,18 @@ import { TicketQR } from '../../../components/TicketQR';
 import React from 'react';
 
 /**
- * Ticket page that displays a QR code for a given ticket ID.  The
- * TicketQR component handles rendering the QR code and actions for
- * downloading or adding to a wallet.
+ * Ticket page that displays a QR code using the glassmorphism layout.
  */
 export default function TicketPage({ params }: { params: { id: string } }) {
   return (
-    <div className="max-w-md">
+    <div className="mx-auto max-w-lg space-y-6">
+      <header className="space-y-2 text-center">
+        <p className="badge inline-flex">Pase listo</p>
+        <h1 className="text-3xl font-semibold text-[var(--color-text-strong)]">Tu entrada</h1>
+        <p className="text-sm text-[var(--color-text-muted)]">
+          Guarda el código en tu dispositivo y muéstralo en el acceso del evento.
+        </p>
+      </header>
       <TicketQR id={params.id} />
     </div>
   );

--- a/apps/guest/components/AppShell.tsx
+++ b/apps/guest/components/AppShell.tsx
@@ -1,0 +1,194 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import React, { ReactNode, useMemo, useState } from 'react';
+import { ThemeToggle } from './ThemeToggle';
+
+const navItems = [
+  { href: '/', label: 'Inicio', description: 'Resumen general de tus actividades' },
+  { href: '/events', label: 'Mis eventos', description: 'Lista de eventos que gestionas' },
+  { href: '/create', label: 'Crear evento', description: 'Configura un nuevo evento' },
+  { href: '/sales', label: 'Ventas', description: 'Revisa desempeño de ventas' },
+  { href: '/settings', label: 'Ajustes', description: 'Preferencias y cuenta' },
+];
+
+type AppShellProps = {
+  children: ReactNode;
+};
+
+const Icon = ({ name, active }: { name: string; active: boolean }) => {
+  const stroke = active ? 'var(--color-text-strong)' : 'var(--color-text)';
+  switch (name) {
+    case 'Inicio':
+      return (
+        <svg width="22" height="22" viewBox="0 0 24 24" role="presentation" aria-hidden="true">
+          <path
+            d="M4.5 10.5 12 4l7.5 6.5v8a1.5 1.5 0 0 1-1.5 1.5h-4.5v-5h-3v5H6a1.5 1.5 0 0 1-1.5-1.5z"
+            fill="none"
+            stroke={stroke}
+            strokeWidth={1.6}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      );
+    case 'Mis eventos':
+      return (
+        <svg width="22" height="22" viewBox="0 0 24 24" role="presentation" aria-hidden="true">
+          <path
+            d="M4 5h16M4 9h16M4 19h16M4 13h8"
+            stroke={stroke}
+            strokeWidth={1.6}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            fill="none"
+          />
+        </svg>
+      );
+    case 'Crear evento':
+      return (
+        <svg width="22" height="22" viewBox="0 0 24 24" role="presentation" aria-hidden="true">
+          <path
+            d="M12 5v14M5 12h14"
+            stroke={stroke}
+            strokeWidth={1.6}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            fill="none"
+          />
+        </svg>
+      );
+    case 'Ventas':
+      return (
+        <svg width="22" height="22" viewBox="0 0 24 24" role="presentation" aria-hidden="true">
+          <path
+            d="M5 15.5 10 9l4 5 5-7"
+            stroke={stroke}
+            strokeWidth={1.6}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            fill="none"
+          />
+          <path d="M4 19h16" stroke={stroke} strokeWidth={1.6} strokeLinecap="round" />
+        </svg>
+      );
+    default:
+      return (
+        <svg width="22" height="22" viewBox="0 0 24 24" role="presentation" aria-hidden="true">
+          <circle cx="12" cy="12" r="6.5" stroke={stroke} strokeWidth={1.6} fill="none" />
+          <path d="M12 8v4l2.5 2.5" stroke={stroke} strokeWidth={1.6} strokeLinecap="round" />
+        </svg>
+      );
+  }
+};
+
+export const AppShell = ({ children }: AppShellProps) => {
+  const pathname = usePathname();
+  const [collapsed, setCollapsed] = useState(false);
+
+  const activePath = useMemo(() => {
+    if (!pathname) return '/';
+    if (pathname.startsWith('/events')) return '/events';
+    if (pathname.startsWith('/create')) return '/create';
+    if (pathname.startsWith('/sales')) return '/sales';
+    if (pathname.startsWith('/settings')) return '/settings';
+    return '/';
+  }, [pathname]);
+
+  return (
+    <div className="flex min-h-screen w-full bg-transparent">
+      <a
+        href="#contenido-principal"
+        className="absolute left-4 top-4 z-[999] -translate-y-24 rounded-full bg-[var(--color-accent)] px-4 py-2 text-sm font-semibold text-[var(--color-text-strong)] shadow-soft focus:translate-y-0 focus:outline-none"
+      >
+        Saltar al contenido
+      </a>
+      <aside
+        className={`glass-card hidden shrink-0 flex-col justify-between border-l-0 border-r border-t-0 border-b-0 p-6 transition-[width] duration-300 ease-in-out md:flex ${collapsed ? 'w-24' : 'w-72'}`}
+      >
+        <div className="flex flex-col gap-8">
+          <button
+            type="button"
+            onClick={() => setCollapsed((prev) => !prev)}
+            className="ml-auto inline-flex items-center gap-2 rounded-full border border-[var(--color-border-soft)] bg-[rgba(255,255,255,0.04)] px-3 py-1 text-xs font-semibold text-[var(--color-text-muted)] transition-base hover:bg-[rgba(75,163,255,0.15)] hover:text-[var(--color-text-strong)]"
+            aria-pressed={collapsed}
+            aria-label={collapsed ? 'Expandir barra lateral' : 'Colapsar barra lateral'}
+          >
+            {collapsed ? '▶' : '◀'}
+          </button>
+          <nav aria-label="Navegación principal" className="flex flex-col gap-2">
+            {navItems.map((item) => {
+              const active = activePath === item.href;
+              return (
+                <Link
+                  key={item.href}
+                  href={item.href}
+                  className={`group flex items-center gap-4 rounded-2xl border border-transparent px-4 py-3 text-sm font-semibold transition-base focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[rgba(7,17,32,0.35)] ${
+                    active
+                      ? 'bg-[rgba(75,163,255,0.18)] text-[var(--color-text-strong)]'
+                      : 'text-[var(--color-text)] hover:bg-[rgba(75,163,255,0.12)] hover:text-[var(--color-text-strong)]'
+                  }`}
+                >
+                  <span className="inline-flex h-9 w-9 flex-none items-center justify-center rounded-xl bg-[rgba(75,163,255,0.18)]">
+                    <Icon name={item.label} active={active} />
+                  </span>
+                  {!collapsed && (
+                    <span className="flex flex-col">
+                      <span>{item.label}</span>
+                      <span className="text-xs font-medium text-[var(--color-text-muted)]">{item.description}</span>
+                    </span>
+                  )}
+                </Link>
+              );
+            })}
+          </nav>
+        </div>
+        <div className="flex flex-col gap-4">
+          <ThemeToggle />
+          <p className={`text-xs leading-5 ${collapsed ? 'hidden' : 'block'} text-[var(--color-text-muted)]`}>
+            Administra tus eventos con un diseño inspirado en glassmorfismo y listo para modo claro y oscuro.
+          </p>
+        </div>
+      </aside>
+      <div className="flex w-full flex-col">
+        <header className="sticky top-0 z-40 flex flex-col gap-4 border-b border-[var(--color-border-soft)] bg-[rgba(8,15,28,0.75)] px-6 py-5 backdrop-blur-2xl md:hidden">
+          <div className="flex items-center justify-between">
+            <div>
+              <p className="badge">Panel</p>
+              <h1 className="mt-2 text-xl font-semibold text-[var(--color-text-strong)]">Monotickets</h1>
+            </div>
+            <ThemeToggle />
+          </div>
+        </header>
+        <main id="contenido-principal" className="flex-1 px-4 pb-24 pt-6 sm:px-8">
+          {children}
+        </main>
+        <nav
+          aria-label="Navegación inferior"
+          className="glass-popover fixed bottom-4 left-1/2 z-40 flex w-[92%] max-w-md -translate-x-1/2 justify-between rounded-full px-6 py-3 shadow-soft transition-base md:hidden"
+        >
+          {navItems.map((item) => {
+            const active = activePath === item.href;
+            return (
+              <Link
+                key={`mobile-${item.href}`}
+                href={item.href}
+                className={`flex flex-col items-center gap-1 text-xs font-semibold transition-base ${
+                  active
+                    ? 'text-[var(--color-text-strong)]'
+                    : 'text-[var(--color-text-muted)] hover:text-[var(--color-text-strong)]'
+                }`}
+              >
+                <span className="grid h-9 w-9 place-items-center rounded-full bg-[rgba(75,163,255,0.18)]">
+                  <Icon name={item.label} active={active} />
+                </span>
+                <span>{item.label}</span>
+              </Link>
+            );
+          })}
+        </nav>
+      </div>
+    </div>
+  );
+};

--- a/apps/guest/components/FeedbackForm.tsx
+++ b/apps/guest/components/FeedbackForm.tsx
@@ -1,14 +1,16 @@
 'use client';
+
 import { useState } from 'react';
 import { Button, Card, useToast } from '@ui/index';
 import { api } from '@api/monotickets-sdk';
 import { motion } from 'framer-motion';
 import React from 'react';
 
+const ratings = [1, 2, 3, 4, 5];
+
 /**
- * Collects feedback from event attendees.  Allows users to rate the
- * event from 1–5 stars and submit a text comment.  After submission
- * it displays a thank-you message.
+ * Collects feedback from event attendees.  Applies the new visual language with
+ * glass surfaces, vivid accents, and improved accessibility states.
  */
 export const FeedbackForm = () => {
   const [rating, setRating] = useState(0);
@@ -20,6 +22,7 @@ export const FeedbackForm = () => {
     try {
       await api.post('/guest/feedback', { rating, message });
       setSent(true);
+      showToast('¡Gracias por compartir tu experiencia! ✨', 'success');
     } catch {
       showToast('Error al enviar feedback ❌', 'error');
     }
@@ -27,37 +30,59 @@ export const FeedbackForm = () => {
 
   if (sent)
     return (
-      <motion.div initial={{ scale: 0.8 }} animate={{ scale: 1 }}>
-        <Card>
-          <h2 className="text-xl font-bold mb-2">¡Gracias por tus comentarios! 💬</h2>
-          <p>Tu opinión nos ayuda a mejorar futuras experiencias.</p>
+      <motion.div initial={{ scale: 0.88, opacity: 0 }} animate={{ scale: 1, opacity: 1 }}>
+        <Card className="space-y-3 text-center">
+          <h2 className="text-2xl font-semibold text-[var(--color-text-strong)]">¡Gracias por tus comentarios! 💬</h2>
+          <p className="text-sm leading-6 text-[var(--color-text)]">
+            Tu opinión nos ayuda a diseñar experiencias inolvidables. Revisa tu correo para recibir sorpresas exclusivas.
+          </p>
+          <Button variant="secondary" onClick={() => setSent(false)}>
+            Enviar otro comentario
+          </Button>
         </Card>
       </motion.div>
     );
 
   return (
-    <Card>
-      <h2 className="text-xl font-bold mb-4">Feedback del evento</h2>
-      <div className="flex gap-2 mb-3">
-        {[1, 2, 3, 4, 5].map((i) => (
-          <button
-            key={i}
-            onClick={() => setRating(i)}
-            className={`text-2xl ${i <= rating ? 'text-yellow-400' : 'text-gray-300'}`}
-            aria-label={`${i} star rating`}
-          >
-            ★
-          </button>
-        ))}
+    <Card className="space-y-6">
+      <header className="space-y-2 text-center">
+        <h2 className="text-2xl font-semibold text-[var(--color-text-strong)]">Feedback del evento</h2>
+        <p className="text-sm text-[var(--color-text-muted)]">
+          Califica tu experiencia y cuéntanos qué podemos mejorar. ¡Todo feedback es bienvenido!
+        </p>
+      </header>
+      <div className="flex items-center justify-center gap-2">
+        {ratings.map((value) => {
+          const active = value <= rating;
+          return (
+            <button
+              key={value}
+              onClick={() => setRating(value)}
+              className={`transition-base text-3xl focus-visible:outline-none ${
+                active ? 'text-[var(--color-accent-strong)] drop-shadow-[0_6px_18px_rgba(75,163,255,0.45)]' : 'text-[var(--color-text-muted)]'
+              }`}
+              aria-label={`${value} de 5 estrellas`}
+              type="button"
+            >
+              ★
+            </button>
+          );
+        })}
       </div>
-      <textarea
-        className="w-full border p-2 rounded mb-3"
-        rows={3}
-        placeholder="Escribe tu comentario..."
-        value={message}
-        onChange={(e) => setMessage(e.target.value)}
-      />
-      <Button onClick={submitFeedback}>Enviar</Button>
+      <label className="flex flex-col gap-3 text-sm font-medium text-[var(--color-text)]">
+        Comentarios adicionales
+        <textarea
+          className="min-h-[120px] rounded-3xl border border-[var(--color-border-soft)] bg-[rgba(255,255,255,0.05)] px-5 py-4 text-[var(--color-text)] shadow-soft transition-base focus-visible:border-[var(--color-accent)]"
+          rows={4}
+          placeholder="Cuéntanos qué te gustó o qué podríamos mejorar..."
+          value={message}
+          onChange={(event) => setMessage(event.target.value)}
+          aria-label="Comentario"
+        />
+      </label>
+      <Button onClick={submitFeedback} disabled={rating === 0 || message.trim().length === 0}>
+        Enviar opinión
+      </Button>
     </Card>
   );
 };

--- a/apps/guest/components/InviteCard.tsx
+++ b/apps/guest/components/InviteCard.tsx
@@ -1,4 +1,5 @@
 'use client';
+
 import Link from 'next/link';
 import { Card, Button } from '@ui/index';
 import { motion } from 'framer-motion';
@@ -15,26 +16,38 @@ type InviteCardProps = {
   invite: Invite;
 };
 
+const cardVariants = {
+  initial: { opacity: 0, y: 28, scale: 0.96 },
+  animate: { opacity: 1, y: 0, scale: 1, transition: { duration: 0.45, ease: 'easeOut' } },
+};
+
 /**
- * Component used to display event invitation details.  It animates into
- * view and provides a call-to-action to confirm attendance via the
- * RSVP page.
+ * Component used to display event invitation details following the refreshed
+ * Monotickets visual system.  Applies glassmorphism, subtle motion, and clear
+ * action hierarchy for accessibility.
  */
 export const InviteCard = React.memo(({ invite }: InviteCardProps) => (
-  <motion.div
-    initial={{ opacity: 0, scale: 0.9 }}
-    animate={{ opacity: 1, scale: 1 }}
-    transition={{ duration: 0.4 }}
-  >
-    <Card>
-      <h2 className="text-2xl font-bold mb-2">{invite.event_name}</h2>
-      <p className="text-gray-600 mb-2">{invite.description}</p>
-      <p className="text-gray-800 mb-2">📅 {invite.date}</p>
-      <p className="text-gray-800 mb-2">📍 {invite.location}</p>
-      <div className="mt-4">
-        <Link href="/rsvp">
-          <Button>Confirmar Asistencia</Button>
-        </Link>
+  <motion.div variants={cardVariants} initial="initial" animate="animate">
+    <Card className="space-y-5">
+      <header className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h2 className="text-3xl font-semibold text-[var(--color-text-strong)]">{invite.event_name}</h2>
+          <p className="text-sm text-[var(--color-text-muted)]">{invite.location}</p>
+        </div>
+        <span className="badge">Invitación exclusiva</span>
+      </header>
+      <p className="text-base leading-7 text-[var(--color-text)]">{invite.description}</p>
+      <div className="rounded-2xl border border-[var(--color-border-soft)] bg-[rgba(255,255,255,0.05)] px-5 py-4">
+        <p className="text-sm font-semibold text-[var(--color-text-strong)]">Fecha y hora</p>
+        <p className="text-sm text-[var(--color-text-muted)]">{invite.date}</p>
+      </div>
+      <div className="flex flex-wrap items-center gap-3">
+        <Button asChild>
+          <Link href="/rsvp">Confirmar asistencia</Link>
+        </Button>
+        <Button asChild variant="secondary">
+          <Link href="/ticket/demo">Ver mi pase</Link>
+        </Button>
       </div>
     </Card>
   </motion.div>

--- a/apps/guest/components/RSVPForm.tsx
+++ b/apps/guest/components/RSVPForm.tsx
@@ -1,4 +1,5 @@
 'use client';
+
 import { useState } from 'react';
 import { Button, Card, useToast } from '@ui/index';
 import { api } from '@api/monotickets-sdk';
@@ -6,9 +7,8 @@ import confetti from 'canvas-confetti';
 import React from 'react';
 
 /**
- * A form that allows guests to confirm or decline attendance.  Upon
- * submission it sends the response to the API and shows a success
- * message along with a confetti animation for positive responses.
+ * A form that allows guests to confirm or decline attendance using the updated
+ * visual language.  Success feedback includes confetti for positive responses.
  */
 export const RSVPForm = () => {
   const [response, setResponse] = useState<'none' | 'yes' | 'no'>('none');
@@ -20,7 +20,12 @@ export const RSVPForm = () => {
     try {
       await api.post('/guest/rsvp', { status });
       setResponse(status);
-      if (status === 'yes') confetti({ particleCount: 120, spread: 70 });
+      if (status === 'yes') {
+        confetti({ particleCount: 160, spread: 70, origin: { y: 0.7 } });
+        showToast('¡Tu asistencia quedó confirmada! 🎟️', 'success');
+      } else {
+        showToast('Gracias por avisarnos, te esperaremos en la próxima.', 'info');
+      }
     } catch {
       showToast('Error enviando RSVP', 'error');
     } finally {
@@ -30,20 +35,30 @@ export const RSVPForm = () => {
 
   if (response !== 'none')
     return (
-      <Card>
-        <h2 className="text-xl font-bold mb-2">
-          {response === 'yes'
-            ? '🎉 ¡Nos alegra verte allí!'
-            : '😔 Lamentamos que no puedas asistir.'}
+      <Card className="space-y-4 text-center">
+        <h2 className="text-2xl font-semibold text-[var(--color-text-strong)]">
+          {response === 'yes' ? '🎉 ¡Nos alegra verte allí!' : '😔 Lamentamos que no puedas asistir.'}
         </h2>
-        <p>Gracias por responder tu invitación.</p>
+        <p className="text-sm leading-6 text-[var(--color-text)]">
+          {response === 'yes'
+            ? 'Te enviaremos tu pase digital y recomendaciones personalizadas en los próximos minutos.'
+            : 'Tu lugar se liberará para otra persona interesada. ¡Gracias por hacérnoslo saber!'}
+        </p>
+        <Button variant="secondary" onClick={() => setResponse('none')}>
+          Modificar mi respuesta
+        </Button>
       </Card>
     );
 
   return (
-    <Card>
-      <h2 className="text-xl font-bold mb-4">Confirmar asistencia</h2>
-      <div className="flex gap-4">
+    <Card className="space-y-6">
+      <header className="space-y-2 text-center">
+        <h2 className="text-2xl font-semibold text-[var(--color-text-strong)]">Confirmar asistencia</h2>
+        <p className="text-sm text-[var(--color-text-muted)]">
+          Cuéntanos si podremos contar contigo. Podrás actualizar tu respuesta cuando quieras.
+        </p>
+      </header>
+      <div className="flex flex-wrap justify-center gap-4">
         <Button onClick={() => sendRSVP('yes')} disabled={loading}>
           Asistiré
         </Button>

--- a/apps/guest/components/ThemeProvider.tsx
+++ b/apps/guest/components/ThemeProvider.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import React, { createContext, useContext, useEffect, useMemo, useState } from 'react';
+
+type Theme = 'light' | 'dark';
+
+type ThemeContextValue = {
+  theme: Theme;
+  setTheme: (theme: Theme) => void;
+  toggleTheme: () => void;
+};
+
+const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
+const STORAGE_KEY = 'monotickets_theme';
+
+const getPreferredTheme = (): Theme => {
+  if (typeof window === 'undefined') return 'dark';
+  const stored = window.localStorage.getItem(STORAGE_KEY) as Theme | null;
+  if (stored === 'light' || stored === 'dark') {
+    return stored;
+  }
+  const prefersLight = window.matchMedia?.('(prefers-color-scheme: light)').matches;
+  return prefersLight ? 'light' : 'dark';
+};
+
+const applyTheme = (theme: Theme) => {
+  if (typeof document === 'undefined') return;
+  const root = document.documentElement;
+  root.setAttribute('data-theme', theme);
+  root.style.setProperty('color-scheme', theme);
+};
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setThemeState] = useState<Theme>(() => getPreferredTheme());
+
+  useEffect(() => {
+    applyTheme(theme);
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem(STORAGE_KEY, theme);
+    }
+  }, [theme]);
+
+  useEffect(() => {
+    const handler = (event: MediaQueryListEvent) => {
+      setThemeState(event.matches ? 'light' : 'dark');
+    };
+
+    const mq = window.matchMedia?.('(prefers-color-scheme: light)');
+    mq?.addEventListener('change', handler);
+    return () => mq?.removeEventListener('change', handler);
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      theme,
+      setTheme: (next: Theme) => setThemeState(next),
+      toggleTheme: () => setThemeState((prev) => (prev === 'light' ? 'dark' : 'light')),
+    }),
+    [theme],
+  );
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+}
+
+export const useTheme = () => {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error('useTheme must be used within ThemeProvider');
+  }
+  return context;
+};

--- a/apps/guest/components/ThemeToggle.tsx
+++ b/apps/guest/components/ThemeToggle.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import React from 'react';
+import { useTheme } from './ThemeProvider';
+
+export const ThemeToggle = () => {
+  const { theme, toggleTheme } = useTheme();
+  const isLight = theme === 'light';
+
+  return (
+    <button
+      type="button"
+      onClick={toggleTheme}
+      className="group inline-flex items-center gap-2 rounded-full border border-[var(--color-border-soft)] bg-[rgba(255,255,255,0.06)] px-4 py-2 text-sm font-semibold text-[var(--color-text)] shadow-soft transition-base hover:bg-[rgba(75,163,255,0.16)] hover:text-[var(--color-text-strong)]"
+      aria-label={`Cambiar a modo ${isLight ? 'oscuro' : 'claro'}`}
+      aria-pressed={isLight ? 'true' : 'false'}
+    >
+      <span
+        aria-hidden
+        className="grid h-6 w-6 place-items-center rounded-full bg-[rgba(75,163,255,0.25)] text-[var(--color-text-strong)] transition-base group-hover:bg-[rgba(75,163,255,0.45)]"
+      >
+        {isLight ? '☀️' : '🌙'}
+      </span>
+      <span className="font-medium">{isLight ? 'Modo claro' : 'Modo oscuro'}</span>
+    </button>
+  );
+};

--- a/apps/guest/components/TicketPurchaseFlow.tsx
+++ b/apps/guest/components/TicketPurchaseFlow.tsx
@@ -1,0 +1,337 @@
+'use client';
+
+import React, { useMemo, useState } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+import { Button, Card, useToast } from '@ui/index';
+import { usePreserveScroll } from '@hooks/usePreserveScroll';
+
+type Event = {
+  id: string;
+  name: string;
+  date: string;
+  location: string;
+  description: string;
+  tags: string[];
+};
+
+type Buyer = {
+  name: string;
+  email: string;
+};
+
+const events: Event[] = [
+  {
+    id: 'mtk-aurora',
+    name: 'Aurora Sessions',
+    date: '15 de noviembre • 20:00 hrs',
+    location: 'Auditorio Metropolitano, CDMX',
+    description: 'Una noche inmersiva con visuales envolventes y música electrónica downtempo.',
+    tags: ['Experiencia 360°', 'Aforo limitado'],
+  },
+  {
+    id: 'mtk-summit',
+    name: 'Summit Creativo 2024',
+    date: '23 de noviembre • 09:00 hrs',
+    location: 'Centro de Innovación, Guadalajara',
+    description: 'Charlas, talleres y networking para mentes creativas y líderes de la industria.',
+    tags: ['Day pass', 'Networking'],
+  },
+  {
+    id: 'mtk-classics',
+    name: 'Noches Clásicas',
+    date: '8 de diciembre • 19:30 hrs',
+    location: 'Teatro Degollado, Guadalajara',
+    description: 'La filarmónica interpreta piezas icónicas en un formato íntimo y multisensorial.',
+    tags: ['VIP disponibles', 'Accesibilidad total'],
+  },
+];
+
+const stepTitles = ['Selecciona un evento', 'Elige tus entradas', 'Datos del comprador', 'Confirma y paga'];
+
+const stepVariants = {
+  initial: { opacity: 0, y: 24, filter: 'blur(10px)' },
+  animate: { opacity: 1, y: 0, filter: 'blur(0px)', transition: { duration: 0.4, ease: 'easeOut' } },
+  exit: { opacity: 0, y: -24, filter: 'blur(8px)', transition: { duration: 0.3, ease: 'easeIn' } },
+};
+
+export const TicketPurchaseFlow = () => {
+  usePreserveScroll('guest-events');
+  const { showToast } = useToast();
+  const [step, setStep] = useState(0);
+  const [selectedEvent, setSelectedEvent] = useState<Event | null>(null);
+  const [ticketCount, setTicketCount] = useState(2);
+  const [buyer, setBuyer] = useState<Buyer>({ name: '', email: '' });
+  const [processing, setProcessing] = useState(false);
+  const [confirmationId, setConfirmationId] = useState<string | null>(null);
+
+  const total = useMemo(() => ticketCount * 650, [ticketCount]);
+
+  const goNext = () => setStep((current) => Math.min(current + 1, stepTitles.length - 1));
+  const goPrev = () => setStep((current) => Math.max(current - 1, 0));
+
+  const resetFlow = () => {
+    setStep(0);
+    setSelectedEvent(null);
+    setTicketCount(2);
+    setBuyer({ name: '', email: '' });
+    setConfirmationId(null);
+    setProcessing(false);
+  };
+
+  const handlePurchase = async () => {
+    setProcessing(true);
+    await new Promise((resolve) => setTimeout(resolve, 1800));
+    const confirmation = `MTK-${Math.floor(Math.random() * 899999 + 100000)}`;
+    setConfirmationId(confirmation);
+    showToast('🎉 Compra confirmada. Revisa tu correo con los detalles.', 'success');
+    setProcessing(false);
+  };
+
+  return (
+    <section className="space-y-6">
+      <header className="flex flex-col gap-3">
+        <p className="badge w-fit">Flujo guiado</p>
+        <h2>{stepTitles[step]}</h2>
+        <p className="max-w-2xl text-sm text-[var(--color-text-muted)]">
+          Simplificamos el proceso para que no pierdas el enfoque: selecciona tu experiencia, confirma tus entradas y realiza el pago
+          en menos de un minuto.
+        </p>
+      </header>
+
+      <ol className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        {stepTitles.map((title, index) => {
+          const active = index === step;
+          const completed = index < step;
+          return (
+            <li
+              key={title}
+              className={`glass-card flex flex-col gap-1 rounded-2xl border px-4 py-3 text-xs font-semibold transition-base ${
+                active
+                  ? 'border-[var(--color-accent)] text-[var(--color-text-strong)]'
+                  : completed
+                    ? 'border-transparent text-[var(--color-text-muted)] opacity-80'
+                    : 'border-transparent text-[var(--color-text-muted)] opacity-70'
+              }`}
+            >
+              <span className="text-[10px] uppercase tracking-[0.25em] text-[var(--color-text-muted)]">Paso {index + 1}</span>
+              <span className="text-sm">{title}</span>
+            </li>
+          );
+        })}
+      </ol>
+
+      <AnimatePresence mode="wait">
+        <motion.div key={step} variants={stepVariants} initial="initial" animate="animate" exit="exit">
+          {step === 0 && (
+            <div className="grid gap-5 md:grid-cols-2 xl:grid-cols-3">
+              {events.map((event) => {
+                const active = selectedEvent?.id === event.id;
+                return (
+                  <Card
+                    key={event.id}
+                    className={`h-full cursor-pointer border-2 transition-base hover:border-[var(--color-accent)] hover:shadow-[0_20px_45px_rgba(75,163,255,0.35)] ${
+                      active ? 'border-[var(--color-accent)] text-[var(--color-text-strong)]' : 'border-transparent'
+                    }`}
+                    component="article"
+                    onClick={() => {
+                      setSelectedEvent(event);
+                      setStep(1);
+                    }}
+                    role="button"
+                    tabIndex={0}
+                    onKeyDown={(eventKey) => {
+                      if (eventKey.key === 'Enter' || eventKey.key === ' ') {
+                        eventKey.preventDefault();
+                        setSelectedEvent(event);
+                        setStep(1);
+                      }
+                    }}
+                    aria-pressed={active}
+                  >
+                    <div className="flex items-center justify-between">
+                      <h3 className="text-lg font-semibold">{event.name}</h3>
+                      <span className="badge text-[10px]">{event.tags[0]}</span>
+                    </div>
+                    <p className="mt-3 text-sm text-[var(--color-text-muted)]">{event.description}</p>
+                    <dl className="mt-6 space-y-2 text-sm">
+                      <div className="flex items-center gap-3">
+                        <span aria-hidden>📅</span>
+                        <div>
+                          <dt className="sr-only">Fecha</dt>
+                          <dd>{event.date}</dd>
+                        </div>
+                      </div>
+                      <div className="flex items-center gap-3">
+                        <span aria-hidden>📍</span>
+                        <div>
+                          <dt className="sr-only">Ubicación</dt>
+                          <dd>{event.location}</dd>
+                        </div>
+                      </div>
+                    </dl>
+                    <div className="mt-6 flex flex-wrap gap-2">
+                      {event.tags.map((tag) => (
+                        <span key={tag} className="rounded-full bg-[rgba(75,163,255,0.18)] px-3 py-1 text-xs text-[var(--color-text-strong)]">
+                          {tag}
+                        </span>
+                      ))}
+                    </div>
+                  </Card>
+                );
+              })}
+            </div>
+          )}
+
+          {step === 1 && selectedEvent && (
+            <Card className="space-y-6">
+              <header className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                  <p className="text-xs uppercase tracking-[0.25em] text-[var(--color-text-muted)]">{selectedEvent.location}</p>
+                  <h3 className="text-2xl font-semibold">{selectedEvent.name}</h3>
+                  <p className="text-sm text-[var(--color-text-muted)]">{selectedEvent.date}</p>
+                </div>
+                <div className="text-right">
+                  <p className="text-sm text-[var(--color-text-muted)]">Precio por entrada</p>
+                  <p className="text-2xl font-semibold text-[var(--color-text-strong)]">$650 MXN</p>
+                </div>
+              </header>
+
+              <div className="flex flex-wrap items-center gap-4">
+                <label className="flex items-center gap-3 text-sm font-medium text-[var(--color-text)]">
+                  Cantidad
+                  <div className="flex items-center rounded-full border border-[var(--color-border-soft)] bg-[rgba(255,255,255,0.05)] shadow-soft">
+                    <button
+                      type="button"
+                      onClick={() => setTicketCount((count) => Math.max(1, count - 1))}
+                      className="h-10 w-10 text-lg text-[var(--color-text)] transition-base hover:text-[var(--color-text-strong)]"
+                      aria-label="Disminuir cantidad"
+                    >
+                      −
+                    </button>
+                    <span className="w-12 text-center text-base font-semibold text-[var(--color-text-strong)]">{ticketCount}</span>
+                    <button
+                      type="button"
+                      onClick={() => setTicketCount((count) => Math.min(10, count + 1))}
+                      className="h-10 w-10 text-lg text-[var(--color-text)] transition-base hover:text-[var(--color-text-strong)]"
+                      aria-label="Aumentar cantidad"
+                    >
+                      +
+                    </button>
+                  </div>
+                </label>
+                <p className="text-sm text-[var(--color-text-muted)]">Máximo 10 entradas por compra.</p>
+              </div>
+
+              <div className="flex items-center justify-between rounded-2xl border border-[var(--color-border-soft)] bg-[rgba(75,163,255,0.08)] px-5 py-4 text-sm">
+                <div>
+                  <p className="font-semibold text-[var(--color-text-strong)]">Total estimado</p>
+                  <p className="text-[var(--color-text-muted)]">Incluye cargos por servicio e IVA.</p>
+                </div>
+                <p className="text-2xl font-semibold text-[var(--color-text-strong)]">${total.toLocaleString('es-MX')} MXN</p>
+              </div>
+
+              <div className="flex flex-wrap justify-between gap-3">
+                <Button variant="secondary" onClick={goPrev}>
+                  Volver a eventos
+                </Button>
+                <Button onClick={goNext}>
+                  Continuar con mis entradas
+                </Button>
+              </div>
+            </Card>
+          )}
+
+          {step === 2 && (
+            <Card className="space-y-5">
+              <header className="space-y-1">
+                <h3 className="text-2xl font-semibold">Datos del comprador</h3>
+                <p className="text-sm text-[var(--color-text-muted)]">
+                  Estos datos se utilizarán para enviar las entradas y notificaciones importantes.
+                </p>
+              </header>
+              <form className="grid gap-5 sm:grid-cols-2" onSubmit={(event) => event.preventDefault()}>
+                <label className="flex flex-col gap-2 text-sm font-medium">
+                  Nombre completo
+                  <input
+                    type="text"
+                    required
+                    value={buyer.name}
+                    onChange={(event) => setBuyer((prev) => ({ ...prev, name: event.target.value }))}
+                    className="rounded-2xl border border-[var(--color-border-soft)] bg-[rgba(255,255,255,0.06)] px-4 py-3 text-[var(--color-text)] shadow-soft transition-base focus-visible:border-[var(--color-accent)]"
+                    placeholder="Ej. Alex Martínez"
+                  />
+                </label>
+                <label className="flex flex-col gap-2 text-sm font-medium">
+                  Correo electrónico
+                  <input
+                    type="email"
+                    required
+                    value={buyer.email}
+                    onChange={(event) => setBuyer((prev) => ({ ...prev, email: event.target.value }))}
+                    className="rounded-2xl border border-[var(--color-border-soft)] bg-[rgba(255,255,255,0.06)] px-4 py-3 text-[var(--color-text)] shadow-soft transition-base focus-visible:border-[var(--color-accent)]"
+                    placeholder="tucorreo@email.com"
+                  />
+                </label>
+              </form>
+              <div className="flex flex-wrap justify-between gap-3">
+                <Button variant="secondary" onClick={goPrev}>
+                  Volver
+                </Button>
+                <Button onClick={() => goNext()} disabled={!buyer.name || !buyer.email}>
+                  Revisar y pagar
+                </Button>
+              </div>
+            </Card>
+          )}
+
+          {step === 3 && selectedEvent && (
+            <Card className="space-y-6">
+              <header className="space-y-2">
+                <h3 className="text-2xl font-semibold text-[var(--color-text-strong)]">Confirma tu compra</h3>
+                <p className="text-sm text-[var(--color-text-muted)]">
+                  Revisa que los datos sean correctos antes de confirmar y realizar el pago seguro.
+                </p>
+              </header>
+              <div className="grid gap-4 sm:grid-cols-2">
+                <div className="rounded-2xl border border-[var(--color-border-soft)] bg-[rgba(255,255,255,0.05)] p-4">
+                  <p className="text-xs uppercase tracking-[0.25em] text-[var(--color-text-muted)]">Evento</p>
+                  <p className="mt-2 text-lg font-semibold text-[var(--color-text-strong)]">{selectedEvent.name}</p>
+                  <p className="text-sm text-[var(--color-text-muted)]">{selectedEvent.date}</p>
+                  <p className="text-sm text-[var(--color-text-muted)]">{selectedEvent.location}</p>
+                </div>
+                <div className="rounded-2xl border border-[var(--color-border-soft)] bg-[rgba(255,255,255,0.05)] p-4">
+                  <p className="text-xs uppercase tracking-[0.25em] text-[var(--color-text-muted)]">Entradas</p>
+                  <p className="mt-2 text-lg font-semibold text-[var(--color-text-strong)]">{ticketCount} {ticketCount === 1 ? 'boleto' : 'boletos'}</p>
+                  <p className="text-sm text-[var(--color-text-muted)]">Total a pagar: ${total.toLocaleString('es-MX')} MXN</p>
+                  <p className="text-sm text-[var(--color-text-muted)]">Comprador: {buyer.name}</p>
+                  <p className="text-sm text-[var(--color-text-muted)]">Contacto: {buyer.email}</p>
+                </div>
+              </div>
+              <div className="flex flex-wrap justify-between gap-3">
+                <Button variant="secondary" onClick={goPrev}>
+                  Editar datos
+                </Button>
+                <div className="flex gap-3">
+                  <Button variant="secondary" onClick={resetFlow}>
+                    Reiniciar
+                  </Button>
+                  <Button onClick={handlePurchase} disabled={processing}>
+                    {processing ? 'Procesando...' : 'Confirmar y pagar' }
+                  </Button>
+                </div>
+              </div>
+              {confirmationId && (
+                <div className="rounded-3xl border border-[var(--color-border-soft)] bg-[rgba(75,163,255,0.12)] px-5 py-4 text-sm text-[var(--color-text-strong)]">
+                  <p className="font-semibold">Código de confirmación: {confirmationId}</p>
+                  <p className="text-[var(--color-text-muted)]">
+                    Recibirás tus boletos digitales y factura en los próximos minutos. ¡Gracias por confiar en Monotickets!
+                  </p>
+                </div>
+              )}
+            </Card>
+          )}
+        </motion.div>
+      </AnimatePresence>
+    </section>
+  );
+};

--- a/apps/guest/components/TicketQR.tsx
+++ b/apps/guest/components/TicketQR.tsx
@@ -1,25 +1,40 @@
 'use client';
+
 import { QRCodeCanvas } from 'qrcode.react';
 import { Card, Button, useToast } from '@ui/index';
 import React from 'react';
 
 /**
- * Displays a QR code for a guest’s ticket along with options to download
- * or add it to a digital wallet.  The QR code library generates a
- * canvas-based QR that is easy to print or scan.
+ * Displays a QR code for a guest’s ticket with elevated glass styling and
+ * accessible controls for download and wallet actions.
  */
 export const TicketQR = ({ id }: { id: string }) => {
   const { showToast } = useToast();
 
   return (
-    <Card>
-      <h2 className="text-xl font-bold mb-4">Tu Pase Digital 🎟️</h2>
-      <div className="flex justify-center mb-4">
-        <QRCodeCanvas value={id} size={200} />
+    <Card className="space-y-6 text-center">
+      <header className="space-y-2">
+        <h2 className="text-2xl font-semibold text-[var(--color-text-strong)]">Tu pase digital 🎟️</h2>
+        <p className="text-sm text-[var(--color-text-muted)]">
+          Muestra este código en la entrada o guárdalo en tu wallet favorito para un acceso más rápido.
+        </p>
+      </header>
+      <div className="mx-auto inline-flex rounded-3xl border border-[var(--color-border-soft)] bg-[rgba(255,255,255,0.08)] p-6 shadow-soft">
+        <QRCodeCanvas
+          value={id}
+          size={220}
+          includeMargin
+          bgColor="rgba(255,255,255,0)"
+          fgColor="#4BA3FF"
+          aria-label="Código QR de tu ticket"
+        />
       </div>
-      <div className="flex justify-center gap-4">
+      <div className="flex flex-wrap justify-center gap-4">
         <Button onClick={() => window.print()}>Descargar PDF</Button>
-        <Button variant="secondary" onClick={() => showToast('Próximamente...', 'info')}>
+        <Button
+          variant="secondary"
+          onClick={() => showToast('Pronto podrás agregar tus pases a Apple/Google Wallet.', 'info')}
+        >
           Agregar al Wallet
         </Button>
       </div>

--- a/apps/guest/next.config.mjs
+++ b/apps/guest/next.config.mjs
@@ -4,6 +4,7 @@ const nextConfig = {
   // Transpile only the packages that need compilation.  The utils package
   // remains plain JS and doesn’t require transpilation here.
   transpilePackages: ['ui', 'api', 'design-tokens'],
+  output: 'standalone',
 };
 
 export default nextConfig;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,48 +1,10 @@
 services:
-  admin:
+  frontend:
     build:
       context: .
       args:
-        APP_NAME: admin
-        APP_DIR: apps/admin
         NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-https://api.monotickets.com}
     environment:
       NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-https://api.monotickets.com}
     ports:
-      - "${ADMIN_PORT:-3000}:3000"
-
-  staff:
-    build:
-      context: .
-      args:
-        APP_NAME: staff
-        APP_DIR: apps/staff
-        NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-https://api.monotickets.com}
-    environment:
-      NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-https://api.monotickets.com}
-    ports:
-      - "${STAFF_PORT:-3001}:3000"
-
-  guest:
-    build:
-      context: .
-      args:
-        APP_NAME: guest
-        APP_DIR: apps/guest
-        NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-https://api.monotickets.com}
-    environment:
-      NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-https://api.monotickets.com}
-    ports:
-      - "${GUEST_PORT:-3002}:3000"
-
-  superadmin:
-    build:
-      context: .
-      args:
-        APP_NAME: superadmin
-        APP_DIR: apps/superadmin
-        NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-https://api.monotickets.com}
-    environment:
-      NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-https://api.monotickets.com}
-    ports:
-      - "${SUPERADMIN_PORT:-3003}:3000"
+      - "${FRONTEND_PORT:-3000}:3000"

--- a/packages/design-tokens/index.ts
+++ b/packages/design-tokens/index.ts
@@ -1,17 +1,36 @@
-// Shared design tokens used across Monotickets applications.  These constants
-// define the color palette and typography scales used throughout the UI.  If
-// you need to adjust the theme (e.g. update the primary brand color), do so
-// here to ensure consistency.
+// Shared design tokens reflecting the refreshed Monotickets visual identity.
+// These tokens centralize color, typography, and effect definitions so that
+// all frontend surfaces stay consistent across applications.
 export const tokens = {
   colors: {
-    primary: '#1D4ED8',
-    secondary: '#9333EA',
-    background: '#F9FAFB',
-    dark: '#111827',
+    background: '#0D1B2A',
+    backgroundMuted: '#11243A',
+    surface: 'rgba(255, 255, 255, 0.08)',
+    surfaceElevated: 'rgba(13, 27, 42, 0.75)',
+    surfaceAlt: '#FFFFFF',
+    text: '#B0B0B0',
+    textStrong: '#FFFFFF',
+    textMuted: '#8891A5',
+    accent: '#4BA3FF',
+    accentHover: '#6CB6FF',
+    border: '#E0E0E0',
+    borderSubtle: 'rgba(255, 255, 255, 0.18)',
+    shadow: 'rgba(4, 9, 20, 0.45)',
   },
   typography: {
-    fontFamily: 'Inter, sans-serif',
-    headingSize: '1.25rem',
-    textSize: '1rem',
+    headingFont: '"Montserrat", "Montserrat Variable", sans-serif',
+    subheadingFont: '"Poppins", "Poppins Variable", sans-serif',
+    bodyFont: '"Inter", "Inter Variable", "Roboto", system-ui, -apple-system, sans-serif',
+    sizes: {
+      h1: '32px',
+      h2: '24px',
+      h3: '20px',
+      body: '16px',
+    },
+  },
+  effects: {
+    blur: '18px',
+    glassOpacity: 0.75,
+    transition: '200ms ease',
   },
 };

--- a/packages/hooks/index.ts
+++ b/packages/hooks/index.ts
@@ -1,16 +1,3 @@
-import { useState, useCallback } from 'react';
-
-// A handy hook to toggle a boolean state.  Useful for modals, dropdowns,
-// accordions, etc.  Returns the current state and a function to toggle it.
-export function useToggle(initial: boolean = false): [boolean, () => void] {
-  const [value, setValue] = useState<boolean>(initial);
-  const toggle = useCallback(() => setValue((v) => !v), []);
-  return [value, toggle];
-}
-
-// A simple hook that provides access to the design tokens.  This can be
-// extended in the future to support dynamic theming.
-import { tokens } from '@tokens/index';
-export function useTokens() {
-  return tokens;
-}
+export * from './useToggle';
+export * from './useTokens';
+export * from './usePreserveScroll';

--- a/packages/hooks/usePreserveScroll.ts
+++ b/packages/hooks/usePreserveScroll.ts
@@ -1,0 +1,31 @@
+'use client';
+
+import { useEffect } from 'react';
+
+const STORAGE_PREFIX = 'monotickets-scroll:';
+
+export function usePreserveScroll(key: string) {
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const storageKey = `${STORAGE_PREFIX}${key}`;
+    const stored = window.sessionStorage.getItem(storageKey);
+
+    if (stored) {
+      const top = Number.parseInt(stored, 10);
+      if (!Number.isNaN(top)) {
+        window.scrollTo({ top });
+      }
+    }
+
+    const handleBeforeUnload = () => {
+      window.sessionStorage.setItem(storageKey, String(window.scrollY));
+    };
+
+    window.addEventListener('beforeunload', handleBeforeUnload);
+
+    return () => {
+      window.sessionStorage.setItem(storageKey, String(window.scrollY));
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+    };
+  }, [key]);
+}

--- a/packages/hooks/useToggle.ts
+++ b/packages/hooks/useToggle.ts
@@ -1,0 +1,9 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+
+export function useToggle(initial: boolean = false): [boolean, () => void] {
+  const [value, setValue] = useState<boolean>(initial);
+  const toggle = useCallback(() => setValue((current) => !current), []);
+  return [value, toggle];
+}

--- a/packages/hooks/useTokens.ts
+++ b/packages/hooks/useTokens.ts
@@ -1,0 +1,5 @@
+import { tokens } from '@tokens/index';
+
+export function useTokens() {
+  return tokens;
+}

--- a/packages/ui/components/Toast.tsx
+++ b/packages/ui/components/Toast.tsx
@@ -3,6 +3,13 @@
 import React, { useEffect } from 'react';
 import { useToast } from '../hooks/useToast';
 
+const typeStyles = {
+  success: 'bg-[rgba(63,201,148,0.92)] text-white',
+  error: 'bg-[rgba(242,95,92,0.92)] text-white',
+  warning: 'bg-[rgba(255,173,79,0.92)] text-[#0d1b2a]',
+  info: 'bg-[rgba(75,163,255,0.92)] text-white',
+};
+
 export const Toast = () => {
   const { message, type, isOpen, hideToast } = useToast();
 
@@ -10,7 +17,7 @@ export const Toast = () => {
     if (isOpen) {
       const timer = setTimeout(() => {
         hideToast();
-      }, 3000);
+      }, 3200);
       return () => clearTimeout(timer);
     }
   }, [isOpen, hideToast]);
@@ -19,16 +26,15 @@ export const Toast = () => {
     return null;
   }
 
-  const colors = {
-    success: 'bg-green-600/90',
-    error: 'bg-red-600/90',
-    warning: 'bg-yellow-600/90',
-    info: 'bg-blue-600/90',
-  };
-
   return (
-    <div className="fixed bottom-4 right-4">
-      <div className={`${colors[type]} text-white rounded-lg shadow-lg px-4 py-3`}>{message}</div>
+    <div className="pointer-events-none fixed bottom-6 right-6 z-[999] flex max-w-sm justify-end">
+      <div
+        role="status"
+        aria-live="assertive"
+        className={`glass-popover pointer-events-auto flex-1 rounded-2xl px-5 py-4 text-sm font-medium shadow-soft transition-base ${typeStyles[type]}`}
+      >
+        {message}
+      </div>
     </div>
   );
 };

--- a/packages/ui/index.tsx
+++ b/packages/ui/index.tsx
@@ -1,35 +1,78 @@
-import React from 'react';
+import React, { cloneElement, isValidElement } from 'react';
 import { Toast } from './components/Toast';
 
-type ButtonProps = {
-  children: React.ReactNode;
-  onClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
+type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
   variant?: 'primary' | 'secondary';
-  disabled?: boolean;
+  asChild?: boolean;
 };
 
-// A simple button component with two variants.  Accepts children as the
-// button label, an optional onClick handler, and an optional variant prop
-// which defaults to "primary".  Styles are based on Tailwind CSS utility
-// classes, but can be overridden or extended via the parent application.
-export const Button = ({ children, onClick, variant = 'primary', disabled }: ButtonProps) => {
-  const base = 'px-4 py-2 rounded font-semibold transition-all';
-  const styles =
-    variant === 'primary'
-      ? 'bg-blue-600 text-white hover:bg-blue-700'
-      : 'bg-gray-200 text-gray-900 hover:bg-gray-300';
+const merge = (...classes: (string | undefined | false)[]) => classes.filter(Boolean).join(' ');
+
+// Primary and secondary button styles aligned with the refreshed UI system.
+export const Button = ({
+  children,
+  onClick,
+  variant = 'primary',
+  disabled,
+  type = 'button',
+  className,
+  asChild = false,
+  ...rest
+}: ButtonProps) => {
+  const base =
+    'inline-flex items-center justify-center gap-2 rounded-xl px-5 py-2.5 font-semibold tracking-wide transition-base focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[var(--color-accent)] focus-visible:ring-offset-[rgba(7,17,32,0.35)] disabled:cursor-not-allowed disabled:opacity-60';
+  const variants: Record<'primary' | 'secondary', string> = {
+    primary:
+      'bg-[var(--color-accent)] text-[var(--color-text-strong)] shadow-soft hover:bg-[var(--color-accent-strong)] hover:shadow-[0_20px_40px_rgba(75,163,255,0.45)]',
+    secondary:
+      'border border-[var(--color-accent)] bg-transparent text-[var(--color-accent)] hover:bg-[rgba(75,163,255,0.12)] hover:text-[var(--color-text-strong)]',
+  };
+  const mergedClassName = merge(base, variants[variant], className);
+
+  if (asChild && isValidElement(children)) {
+    return cloneElement(children as React.ReactElement, {
+      className: merge(mergedClassName, (children.props as { className?: string }).className),
+      onClick,
+      ...rest,
+    } as Record<string, unknown>);
+  }
+
   return (
-    <button onClick={onClick} className={`${base} ${styles}`} disabled={disabled}>
+    <button
+      type={type}
+      onClick={onClick}
+      className={mergedClassName}
+      disabled={disabled}
+      {...rest}
+    >
       {children}
     </button>
   );
 };
 
-// A simple card component for wrapping content.  Uses a white background,
-// subtle shadow, and rounded corners.  Children are rendered inside.
-export const Card = ({ children }: { children: React.ReactNode }) => (
-  <div className="p-4 bg-white shadow-md rounded-lg border border-gray-100">{children}</div>
-);
+type CardProps<T extends React.ElementType = 'section'> = {
+  children: React.ReactNode;
+  className?: string;
+  component?: T;
+} & Omit<React.ComponentPropsWithoutRef<T>, 'children' | 'className'>;
+
+// Glassmorphism inspired card that adapts to light/dark themes via CSS variables.
+export const Card = <T extends React.ElementType = 'section'>({
+  children,
+  className,
+  component,
+  ...rest
+}: CardProps<T>) => {
+  const Component = (component || 'section') as React.ElementType;
+  return (
+    <Component
+      {...(rest as Record<string, unknown>)}
+      className={merge('glass-card rounded-3xl border backdrop-blur-xl px-6 py-6 text-[var(--color-text)]', className)}
+    >
+      {children}
+    </Component>
+  );
+};
 
 export { Toast };
 export * from './hooks';


### PR DESCRIPTION
## Summary
- apply the updated Monotickets palette, typography, and glassmorphism styling to the guest application with responsive navigation and dark-mode toggle support
- streamline the ticket purchase journey with a guided stepper, scroll preservation hook, and dedicated pages for events, creation, sales, and settings
- add a standalone Next.js Docker image and simplified docker-compose configuration for the guest frontend

## Testing
- pnpm --filter guest build

------
https://chatgpt.com/codex/tasks/task_e_68e34545cb50832f8c810ccd3335a5bb